### PR TITLE
First version of data generation from the Copernicus Climate Data Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+data/download.nc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,44 @@
-# realtime-demo
-A demo for CrateDB's realtime analytics capabilities
+# Real-Time Demo
+
+A demo of CrateDB's real-time analytics capabilities.
+
+## Data Generation
+
+We use publicly available data from the [Climate Data Store](https://cds.climate.copernicus.eu/). The [ERA5-Land](https://cds.climate.copernicus.eu/datasets/derived-era5-land-daily-statistics?tab=overview) data set includes atmospheric variables, such as air temperature and air humidity from around the globe.
+
+[data/parser.py](data/parser.py) generates a report for a given date range, parses the retrieved NetCDF file, and converts it to JSON documents. Below is an example of the final JSON document.
+
+```json
+{
+    "timestamp": 1756684800000000000,
+    "temperature": 295.6215515136719,
+    "latitude": 40.90000000000115,
+    "longitude": 31.100000000000172
+}
+```
+
+### Prerequisites
+
+You will need access to the Climate Data Store API. Please retrieve your personal [CDSAPI key](https://cds.climate.copernicus.eu/how-to-api) and store it in `~/.cdsapirc`:
+
+```bash
+echo "url: https://cds.climate.copernicus.eu/api
+key: INSERT-YOUR-KEY" > a
+```
+
+Then follow the steps below to set up a virtual Python environment and install dependencies:
+
+```bash
+cd data
+python3 -m venv .venv
+source .venv/bin/activate
+pip3 install -U -r requirements.txt
+```
+
+### Execution
+
+To run the parser, simply execute it. If you want to adjust the date range that will be downloaded, please edit the `main` method accordingly.
+
+```bash
+python3 parser.py
+```

--- a/data/parser.py
+++ b/data/parser.py
@@ -1,0 +1,74 @@
+"""
+This script processes a report from the EU Copernicus Climate Data Store.
+
+Processing consists of:
+1. Generating and downloading a given report
+2. Converting the NetCDF file to JSON
+"""
+from typing import Any, Dict, List
+import cdsapi
+import numpy as np
+import xarray as xr
+
+# The name of the file to store the report
+FILE_NAME: str = "download.nc"
+# The name of the variable we are interested in to extract from the report.
+# t2m stands for temperature 2 meters above the ground.
+VARIABLE_NAME: str = "t2m"
+
+
+def download_file(dataset: str, request: Dict[Any, Any]) -> None:
+    "Downloads and saves the requested dataset"
+    client = cdsapi.Client()
+    client.retrieve(dataset, request, FILE_NAME)
+
+
+def to_json() -> List[Dict]:
+    "Parses the NetCDF file and converts it to a JSON document"
+    xrds = xr.open_dataset(FILE_NAME)
+
+    df = xrds.data_vars[VARIABLE_NAME].to_dataframe()
+
+    result = []
+    for _, row in df.iterrows():
+        value = row[VARIABLE_NAME].item()
+        # Some measurements don't have a value, we skip those
+        if np.isnan(value):
+            continue
+
+        result.append(
+            {
+                "timestamp": row.name[0].value,
+                "temperature": value,
+                "latitude": row.name[1],
+                "longitude": row.name[2],
+            }
+        )
+
+    return result
+
+
+def main() -> None:
+    "Main method to initiate the download and parsing"
+
+    dataset = "derived-era5-land-daily-statistics"
+    request = {
+        "variable": ["2m_temperature"],
+        "year": "2025",
+        "month": "09",
+        "day": ["01"],
+        "daily_statistic": "daily_mean",
+        "time_zone": "utc+00:00",
+        "frequency": "1_hourly",
+        "data_format": "netcdf",
+        "download_format": "unarchived",
+    }
+
+    download_file(dataset, request)
+    # TODO This is ignoring the returned data. In the next steps,
+    # data needs to be written into a message queue
+    to_json()
+
+
+if __name__ == "__main__":
+    main()

--- a/data/requirements.txt
+++ b/data/requirements.txt
@@ -1,0 +1,5 @@
+cdsapi < 0.8
+numpy < 2.4
+# Required by xarray to process NetCDF files
+netcdf4 < 1.8
+xarray < 2025.11


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

This is preparing the data production for our real-time demo. Please see the updated [README.md](https://github.com/crate/realtime-demo/blob/hammerhead/data/README.md).

For now, the script downloads and converts a report from the [Climate Data Store](https://cds.climate.copernicus.eu/datasets/derived-era5-land-daily-statistics?tab=overview) to JSON.

### Outlook

In a second step, the JSON documents can be inserted into a message queue at a configurable rate.

## Checklist

 - [X] Link to issue this PR refers to (if applicable): Fixes #???
