### PR TITLE
Remove unused `AWS_REGION` parameter

### DIFF
--- a/data/.env.example
+++ b/data/.env.example
@@ -1,4 +1,3 @@
-AWS_REGION="us-east-1"
 # https://docs.aws.amazon.com/msk/latest/developerguide/msk-get-bootstrap-brokers.html
 AWS_MSK_BOOTSTRAP_SERVER="boot-example.c2.kafka-serverless.eu-central-1.amazonaws.com:9098"
 AWS_MSK_TOPIC_NAME="dev-1"

--- a/data/msk_kafka_admin.py
+++ b/data/msk_kafka_admin.py
@@ -7,7 +7,7 @@ from kafka.admin import KafkaAdminClient, NewTopic
 class MSKKafkaAdmin:
     "A Kafka administration client"
 
-    def __init__(self, aws_region: str, bootstrap_server: str) -> None:
+    def __init__(self, bootstrap_server: str) -> None:
         "Initializes the client for a given bootstrap server"
         self.client = KafkaAdminClient(
             bootstrap_servers=bootstrap_server,

--- a/data/msk_kafka_producer.py
+++ b/data/msk_kafka_producer.py
@@ -8,7 +8,7 @@ from kafka import KafkaProducer
 class MSKKafkaProducer:
     "A Kafka Producer class that instantiates a client and writes data"
 
-    def __init__(self, aws_region: str, bootstrap_server: str) -> None:
+    def __init__(self, bootstrap_server: str) -> None:
         "Creates a new Kafka producer for a given bootstrap server URL"
         self.producer = KafkaProducer(
             bootstrap_servers=bootstrap_server,

--- a/data/producer.py
+++ b/data/producer.py
@@ -37,10 +37,7 @@ def main() -> None:
     """
     topic_name = os.environ["AWS_MSK_TOPIC_NAME"]
 
-    kafka_admin = MSKKafkaAdmin(
-        os.environ["AWS_REGION"],
-        os.environ["AWS_MSK_BOOTSTRAP_SERVER"],
-    )
+    kafka_admin = MSKKafkaAdmin(os.environ["AWS_MSK_BOOTSTRAP_SERVER"])
 
     # Create the topic if it doesn't exist yet
     kafka_admin.topic_create(
@@ -64,10 +61,8 @@ def main() -> None:
     logger.info("Received %s combined JSON documents", len(json_documents))
 
     # Ingest the data into AWS MSK
-    kafka_producer = MSKKafkaProducer(
-        os.environ["AWS_REGION"],
-        os.environ["AWS_MSK_BOOTSTRAP_SERVER"],
-    )
+    kafka_producer = MSKKafkaProducer(os.environ["AWS_MSK_BOOTSTRAP_SERVER"])
+
     logger.info("Starting data ingestion")
     i = 0
     for document in json_documents:


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

It wasn't used in the producer (became obsolete with 4d2f909f250123fbddcce9056dcc6ba5a5df492f).

## Checklist

 - [X] Link to issue this PR refers to (if applicable): Fixes #???
