### PR TITLE
CI: Run Dependabot more frequently

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/data"
     schedule:
-      interval: "monthly"
+      interval: "daily"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## About
Just maintenance: Get informed about dependency updates more frequently. This policy matches the relaxed version pinning style found in this repository; with stricter version pinning, Dependabot traffic would become too high.